### PR TITLE
Rspec and rubocop should be non-development dependencies

### DIFF
--- a/fastlane-plugin-ruby.gemspec
+++ b/fastlane-plugin-ruby.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  spec.add_dependency 'rspec'
+  spec.add_dependency 'rubocop'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'fastlane', '>= 1.90.0'
 end


### PR DESCRIPTION
Since rspce and rubocop actions are made available to plugin users, both rspec and rubocop gems need to be part of the bundle
So unless rubocop is directly added by plugin users to Gemfile, the rubocop action will fail with message like this:
bundler: command not found: rubocop